### PR TITLE
Decouple deployment pipeline from RAILS_ENV

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -14,14 +14,20 @@ CDN_HOST=$(cat "$ENV_DIR/CDN_HOST")
 CDN_URL="https://$CDN_HOST/$SOURCE_VERSION"
 POLL_INTERVAL=10
 HEROKU_BRANCH=master
-RAILS_ENV=$(cat "$ENV_DIR/RAILS_ENV" | tr '[:lower:]' '[:upper:]')
+
+# Use DEPLOYMENT_ENV if available, otherwise fallback to RAILS_ENV
+if [ -f "$ENV_DIR/DEPLOYMENT_ENV" ]; then
+  DEPLOYMENT_ENV=$(cat "$ENV_DIR/DEPLOYMENT_ENV" | tr '[:lower:]' '[:upper:]')
+else
+  DEPLOYMENT_ENV=$(cat "$ENV_DIR/RAILS_ENV" | tr '[:lower:]' '[:upper:]')
+fi
 
 echo
 echo "          --------------------------------------------------"
 echo "          Commit SHA        : $SOURCE_VERSION"
 echo "          CDN URL           : $CDN_URL"
 echo "          Heroku Branch     : $HEROKU_BRANCH"
-echo "          Rails Environment : $RAILS_ENV"
+echo "          Deployment Env    : $DEPLOYMENT_ENV"
 echo "          --------------------------------------------------"
 echo
 
@@ -32,7 +38,7 @@ HARNESS_ORG_IDENTIFIER=$(cat "$ENV_DIR/HARNESS_ORG_IDENTIFIER")
 HARNESS_PROJECT_IDENTIFIER=$(cat "$ENV_DIR/HARNESS_PROJECT_IDENTIFIER")
 HARNESS_PIPELINE_IDENTIFIER=$(cat "$ENV_DIR/HARNESS_PIPELINE_IDENTIFIER")
 HARNESS_TRIGGER_IDENTIFIER=$(cat "$ENV_DIR/HARNESS_TRIGGER_IDENTIFIER")
-HARNESS_WEBHOOK_PAYLOAD="{\"commitSha\": \"$SOURCE_VERSION\", \"branch\": \"$HEROKU_BRANCH\", \"env\": \"$RAILS_ENV\"}"
+HARNESS_WEBHOOK_PAYLOAD="{\"commitSha\": \"$SOURCE_VERSION\", \"branch\": \"$HEROKU_BRANCH\", \"env\": \"$DEPLOYMENT_ENV\"}"
 
 # Construct URL
 WEBHOOK_URL="${HARNESS_WEBHOOK_BASE_URL}?accountIdentifier=${HARNESS_ACCOUNT_IDENTIFIER}&orgIdentifier=${HARNESS_ORG_IDENTIFIER}&projectIdentifier=${HARNESS_PROJECT_IDENTIFIER}&pipelineIdentifier=${HARNESS_PIPELINE_IDENTIFIER}&triggerIdentifier=${HARNESS_TRIGGER_IDENTIFIER}"

--- a/bin/compile
+++ b/bin/compile
@@ -13,7 +13,13 @@ function get_env_var() {
   if [ -f "$ENV_DIR/$var_name" ]; then
     echo "$(cat "$ENV_DIR/$var_name")"
   else
-    echo "$default_value"
+    if [ -n "$default_value" ]; then
+      echo "$default_value"
+    else
+      echo "❌ Error: Required environment variable '$var_name' is not set and no default value was provided." >&2
+      echo "   Please set the $var_name environment variable and try again." >&2
+      exit 1
+    fi
   fi
 }
 

--- a/bin/compile
+++ b/bin/compile
@@ -7,20 +7,26 @@ CACHE_DIR=$2
 ENV_DIR=$3
 BUILDPACK_DIR=$(cd "$(dirname "${0:-}")"; cd ..; pwd)
 
-# Max number of minutes we'll wait for the remote build to finish.
-REMOTE_BUILD_TIMEOUT_MINUTES=$(cat "$ENV_DIR/REMOTE_BUILD_TIMEOUT_MINUTES")
+function get_env_var() {
+  local var_name=$1
+  local default_value=$2
+  if [ -f "$ENV_DIR/$var_name" ]; then
+    echo "$(cat "$ENV_DIR/$var_name")"
+  else
+    echo "$default_value"
+  fi
+}
 
-CDN_HOST=$(cat "$ENV_DIR/CDN_HOST")
+# Max number of minutes we'll wait for the remote build to finish.
+REMOTE_BUILD_TIMEOUT_MINUTES=$(get_env_var "REMOTE_BUILD_TIMEOUT_MINUTES" "10")
+
+CDN_HOST=$(get_env_var "CDN_HOST")
 CDN_URL="https://$CDN_HOST/$SOURCE_VERSION"
 POLL_INTERVAL=10
 HEROKU_BRANCH=master
 
 # Use CDN_ENV if available, otherwise fallback to RAILS_ENV
-if [ -f "$ENV_DIR/CDN_ENV" ]; then
-  CDN_ENV=$(cat "$ENV_DIR/CDN_ENV" | tr '[:lower:]' '[:upper:]')
-else
-  CDN_ENV=$(cat "$ENV_DIR/RAILS_ENV" | tr '[:lower:]' '[:upper:]')
-fi
+CDN_ENV=$(get_env_var "CDN_ENV" "$(get_env_var "RAILS_ENV")")
 
 echo
 echo "          --------------------------------------------------"
@@ -32,12 +38,12 @@ echo "          --------------------------------------------------"
 echo
 
 # Webhook variables
-HARNESS_WEBHOOK_BASE_URL=$(cat "$ENV_DIR/HARNESS_WEBHOOK_BASE_URL")
-HARNESS_ACCOUNT_IDENTIFIER=$(cat "$ENV_DIR/HARNESS_ACCOUNT_IDENTIFIER")
-HARNESS_ORG_IDENTIFIER=$(cat "$ENV_DIR/HARNESS_ORG_IDENTIFIER")
-HARNESS_PROJECT_IDENTIFIER=$(cat "$ENV_DIR/HARNESS_PROJECT_IDENTIFIER")
-HARNESS_PIPELINE_IDENTIFIER=$(cat "$ENV_DIR/HARNESS_PIPELINE_IDENTIFIER")
-HARNESS_TRIGGER_IDENTIFIER=$(cat "$ENV_DIR/HARNESS_TRIGGER_IDENTIFIER")
+HARNESS_WEBHOOK_BASE_URL=$(get_env_var "HARNESS_WEBHOOK_BASE_URL")
+HARNESS_ACCOUNT_IDENTIFIER=$(get_env_var "HARNESS_ACCOUNT_IDENTIFIER")
+HARNESS_ORG_IDENTIFIER=$(get_env_var "HARNESS_ORG_IDENTIFIER")
+HARNESS_PROJECT_IDENTIFIER=$(get_env_var "HARNESS_PROJECT_IDENTIFIER")
+HARNESS_PIPELINE_IDENTIFIER=$(get_env_var "HARNESS_PIPELINE_IDENTIFIER")
+HARNESS_TRIGGER_IDENTIFIER=$(get_env_var "HARNESS_TRIGGER_IDENTIFIER")
 HARNESS_WEBHOOK_PAYLOAD="{\"commitSha\": \"$SOURCE_VERSION\", \"branch\": \"$HEROKU_BRANCH\", \"env\": \"$CDN_ENV\"}"
 
 # Construct URL

--- a/bin/compile
+++ b/bin/compile
@@ -15,11 +15,11 @@ CDN_URL="https://$CDN_HOST/$SOURCE_VERSION"
 POLL_INTERVAL=10
 HEROKU_BRANCH=master
 
-# Use DEPLOYMENT_ENV if available, otherwise fallback to RAILS_ENV
-if [ -f "$ENV_DIR/DEPLOYMENT_ENV" ]; then
-  DEPLOYMENT_ENV=$(cat "$ENV_DIR/DEPLOYMENT_ENV" | tr '[:lower:]' '[:upper:]')
+# Use CDN_ENV if available, otherwise fallback to RAILS_ENV
+if [ -f "$ENV_DIR/CDN_ENV" ]; then
+  CDN_ENV=$(cat "$ENV_DIR/CDN_ENV" | tr '[:lower:]' '[:upper:]')
 else
-  DEPLOYMENT_ENV=$(cat "$ENV_DIR/RAILS_ENV" | tr '[:lower:]' '[:upper:]')
+  CDN_ENV=$(cat "$ENV_DIR/RAILS_ENV" | tr '[:lower:]' '[:upper:]')
 fi
 
 echo
@@ -27,7 +27,7 @@ echo "          --------------------------------------------------"
 echo "          Commit SHA        : $SOURCE_VERSION"
 echo "          CDN URL           : $CDN_URL"
 echo "          Heroku Branch     : $HEROKU_BRANCH"
-echo "          Deployment Env    : $DEPLOYMENT_ENV"
+echo "          CDN Env           : $CDN_ENV"
 echo "          --------------------------------------------------"
 echo
 
@@ -38,7 +38,7 @@ HARNESS_ORG_IDENTIFIER=$(cat "$ENV_DIR/HARNESS_ORG_IDENTIFIER")
 HARNESS_PROJECT_IDENTIFIER=$(cat "$ENV_DIR/HARNESS_PROJECT_IDENTIFIER")
 HARNESS_PIPELINE_IDENTIFIER=$(cat "$ENV_DIR/HARNESS_PIPELINE_IDENTIFIER")
 HARNESS_TRIGGER_IDENTIFIER=$(cat "$ENV_DIR/HARNESS_TRIGGER_IDENTIFIER")
-HARNESS_WEBHOOK_PAYLOAD="{\"commitSha\": \"$SOURCE_VERSION\", \"branch\": \"$HEROKU_BRANCH\", \"env\": \"$DEPLOYMENT_ENV\"}"
+HARNESS_WEBHOOK_PAYLOAD="{\"commitSha\": \"$SOURCE_VERSION\", \"branch\": \"$HEROKU_BRANCH\", \"env\": \"$CDN_ENV\"}"
 
 # Construct URL
 WEBHOOK_URL="${HARNESS_WEBHOOK_BASE_URL}?accountIdentifier=${HARNESS_ACCOUNT_IDENTIFIER}&orgIdentifier=${HARNESS_ORG_IDENTIFIER}&projectIdentifier=${HARNESS_PROJECT_IDENTIFIER}&pipelineIdentifier=${HARNESS_PIPELINE_IDENTIFIER}&triggerIdentifier=${HARNESS_TRIGGER_IDENTIFIER}"


### PR DESCRIPTION
# Context

In order to enable gated deployments for all environments, they need to share the same CDN, s3 bucket and overall static assets infrastructure. Compile once, deploy everywhere.

Our current heroku buildpack ties the compilation process to the specific RAILS_ENV we're using. This was not a problem for staging an demo, because both environments have RAILS_ENV=staging. However, production and sandbox has it set to "production".

This value is sent in the payload of the webhook that triggers the FE compilation on Harness, and instructs the Harness pipeline about how to choose the right cloudfront distribution, s3 bucket and access keys.

# Proposed Solution

Introduce DEPLOYMENT_ENV variable to control CDN and compilation processes independently of Rails environment settings. This allows multiple production environments to share the same deployment configuration. By setting this on the individual heroku apps, we can direct assets compilation/retrieval to any arbitrary bucket/configuration, regardless of RAILS_ENV.

Changes:
- Add DEPLOYMENT_ENV variable with fallback to RAILS_ENV for backward compatibility
- Support only 'production' and 'development' deployment environments
- Update webhook payload to use DEPLOYMENT_ENV instead of RAILS_ENV
- Modify console output to display "Deployment Env" instead of "Rails Environment"

This enables:
- Production deployments (staging, sandbox, demo, production) to use 'production' deployment env
- Review apps, PR builds, and merge queue builds to use 'development' deployment env
- Gradual migration without breaking existing deployments